### PR TITLE
Lazy dependency loading for circular dependencies.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,22 +16,30 @@ var DEFINITION_TYPES = [
     'unionTypes',
     'scalarTypes',
     'enumTypes',
+    'lazyDependencies'
 ]
 generator.deps = function () {
     var mixed = {}
     DEFINITION_TYPES.forEach(function (typeName) {
+      if (typeName != 'lazyDependencies')
         mixed[typeName] = {}
+      else
+        mixed[typeName] = []
     })
 
     Array.prototype.forEach.call(arguments, function (arg) {
-        DEFINITION_TYPES.forEach(function (typeName) {
-            for (var key in arg[typeName]) {
-                if (Object.hasOwnProperty.call(arg[typeName], key)) {
-                    mixed[typeName][key] = arg[typeName][key]
-                }
-            }
-        })
+        if (typeof arg === typeof Function) {
+          mixed['lazyDependencies'].push(arg)
+        } else
+          DEFINITION_TYPES.forEach(function (typeName) {
+              for (var key in arg[typeName]) {
+                  if (Object.hasOwnProperty.call(arg[typeName], key)) {
+                      mixed[typeName][key] = arg[typeName][key]
+                  }
+              }
+          })
     })
 
     return mixed
 }
+


### PR DESCRIPTION
This allows the user to pass a function parameter to .deps(), which will be called to resolve the dependency lazily.

This allows graphql-generator to be used with circular dependencies.